### PR TITLE
Add Julia implementation without packing, and add c++ headers

### DIFF
--- a/cpu.jl
+++ b/cpu.jl
@@ -1,0 +1,60 @@
+using LoopVectorization, LinearAlgebra
+
+function kernel_turbo!(C,A,B,β)
+  @turbo for n = indices((C,B),2), m = indices((C,A),1)
+    Cmn = zero(eltype(C))
+    for k = indices((A,B),(2,1))
+      Cmn += A[m,k]*B[k,n]
+    end
+    C[m,n] = β===static(false) ? Cmn : Cmn + C[m,n]
+  end
+end
+function matmul_turbo!(C,A,B)
+  N = LinearAlgebra.checksquare(C)
+  NA = LinearAlgebra.checksquare(A)
+  NB = LinearAlgebra.checksquare(B)
+  @assert N==NA==NB
+  S3 = 64;
+  S2 = 120;
+  S1 = 240;
+  @assert N%S3==0 && N % S1 == 0
+  m = 0
+  while m < N
+    n = 0
+    while n < N
+      @views kernel_turbo!(
+        C[1+m:m+S3,1+n:n+S2],
+        A[1+m:m+S3,1:S1],
+        B[1:S1,1+n:n+S2], static(false))
+      k = S1
+      while k < N
+        @views kernel_turbo!(
+          C[1+m:m+S3,1+n:n+S2],
+          A[1+m:m+S3,1+k:k+S1],
+          B[1+k:k+S1,1+n:n+S2], static(true))
+        k += S1
+      end      
+      n += S2
+    end    
+    m += S3  
+  end
+end
+
+
+run(`clang++ -std=c++17 -O3 -ffast-math -funroll-loops cpu.cpp -shared -fPIC -o libmatmul.so`)
+const libcppmatmul = joinpath(pwd(), "libmatmul.so")
+function matmul_cpp!(C,A,B)
+  N = LinearAlgebra.checksquare(C)
+  NA = LinearAlgebra.checksquare(A)
+  NB = LinearAlgebra.checksquare(B)
+  @assert N==NA==NB
+  @ccall libcppmatmul.matmul6(B::Ptr{Float32}, A::Ptr{Float32}, C::Ptr{Float32}, (N%Int32)::Int32)::Cvoid
+end
+
+N=15*128*2*2;
+T=Float32;M=K=N; A=rand(T,M,K);B=rand(T,K,N);C=Matrix{T}(undef,M,N);
+@time matmul_turbo!(C,A,B);
+C2 = similar(C);
+@time matmul_cpp!(C2,A,B);
+@assert C ≈ C2
+


### PR DESCRIPTION
Note that this is a PR into the `m` branch, not into `main`.

On my M1 mini, I get
```julia
julia> @time matmul_cpp!(C2,A,B);
 13.511781 seconds (3.07 k allocations: 212.762 KiB, 0.11% compilation time)

julia> @time matmul_turbo!(C,A,B);
 12.596438 seconds

julia> C ≈ C2
true
```

Note that these sizes are much too large for LoopVectorization.jl to handle itself, so I simply mirrored the blocking pattern you used for `matmul6`.

What LoopVectorization.jl does is basically just
https://github.com/certik/matmul/blob/945cc224e4a52adac543c21f4aa0fc91d049eea2/cpu.cpp#L266-L268
Plus choosing the parameters to use, permuting loops, etc.
The extra outer loops or any memory copying, you have to do yourself.

LoopVectorization should get a much higher percentage of peak flops at much smaller sizes.
```julia
julia> N=96;

julia> T=Float32;M=K=N; A=rand(T,M,K);B=rand(T,K,N);C=Matrix{T}(undef,M,N);

julia> using LoopVectorization, BenchmarkTools

julia> function matmul_direct!(C,A,B)
           @turbo for n = indices((C,B),2), m = indices((C,A),1)
               Cmn = zero(eltype(C))
               for k = indices((A,B),(2,1))
                   Cmn += A[m,k]*B[k,n]
               end               C[m,n]=Cmn
           end
       end
matmul_direct! (generic function with 1 method)

julia> @benchmark matmul_direct!($C,$A,$B)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  18.375 μs …  26.375 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     18.458 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   18.509 μs ± 302.714 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂▄▆█▇▇ ▁▃                        ▁ ▂                         ▂
  ██████▁██▆▄▁▁▁▁▁▁▁▁▁▁▃▁▃▁▁▁▁▃▁▁▅▇███▁▆▆▁▁▃▁▃▃▃▃▄▁▁▄▁▁▃▁▅▆█▆▇ █
  18.4 μs       Histogram: log(frequency) by time      19.6 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> 100 * 0.0625N^3 / (18.458e-6*3.2e9)
93.61794343915918

julia> N*=2
192

julia> T=Float32;M=K=N; A=rand(T,M,K);B=rand(T,K,N);C=Matrix{T}(undef,M,N);

julia> @benchmark matmul_direct!($C,$A,$B)
BenchmarkTools.Trial: 6636 samples with 1 evaluation.
 Range (min … max):  148.791 μs … 165.417 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     149.083 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   149.754 μs ±   1.796 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▅██▃     ▃▅▁                            ▁▃▃▁                  ▂
  ████▃▃▄▅▆███▅▆▆▅▃▆▅▆▃▅▆▄▃▁▆▃▆▅▆▆▆▃▇▇█▇▆▆████▅▅▄▄▄▄▇▇▅▅▅▆▅▃▄▃▄ █
  149 μs        Histogram: log(frequency) by time        157 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> 100 * 0.0625N^3 / (149.083e-6*3.2e9)
92.7268702668983
```
Without the extra blocking, performance falls off a cliff.

Optimizing blocking behavior can be tricky.

Octavian.jl actually does extremely badly here -- I got 17s vs the 13.5 and 12.6s. It needs a lot of work for Apple silicon, but hasn't been a priority for a long time.
The main interest was just to get some more familiarity with cache optimization for when I finally am able to implement it.